### PR TITLE
[ cabal ] support for ghc 8.10.1

### DIFF
--- a/newtype.cabal
+++ b/newtype.cabal
@@ -22,7 +22,7 @@ source-repository head
 library
   exposed-modules:     Control.Newtype
 
-  build-depends:       base >= 4.3 && < 4.14
+  build-depends:       base >= 4.3 && < 4.15
   if !impl(ghc >= 8.0)
     build-depends:     transformers >= 0.2.2.0 && < 0.6
 


### PR DESCRIPTION
We are using newtype in msp-strath/Mary and are trying to get support for ghc 8.10.1.