### PR TITLE
Avoid braces in `newtype.cabal`

### DIFF
--- a/newtype.cabal
+++ b/newtype.cabal
@@ -52,6 +52,7 @@ library
 
   if impl(ghc >= 7.2)
     default-extensions: Trustworthy
-    if impl(ghc >= 7.10) { ghc-options: -fno-warn-trustworthy-safe }
+    if impl(ghc >= 7.10)
+      ghc-options: -fno-warn-trustworthy-safe
 
   ghc-options: -Wall


### PR DESCRIPTION
With this change, MicroHs can compile `newtype` (once https://github.com/augustss/MicroHs/pull/370 is merged).